### PR TITLE
fix order of Rt, R1 in internal computation of SO(3) tangent vector

### DIFF
--- a/src/loss.jl
+++ b/src/loss.jl
@@ -68,6 +68,6 @@ function so3_tangent_coordinates_stack(R1::AbstractArray{T,3}, Rt::AbstractArray
     return tangent
 end
 
-function so3_tangent_coordinates_stack(rhat::AbstractArray{T,4}, r::AbstractArray{T,4}) where T
-    return reshape(so3_tangent_coordinates_stack(reshape(rhat, 3, 3, :), reshape(r, 3, 3, :)), 3, size(rhat,3), size(rhat,4))
+function so3_tangent_coordinates_stack(R1::AbstractArray{T,4}, Rt::AbstractArray{T,4}) where T
+    return reshape(so3_tangent_coordinates_stack(reshape(R1, 3, 3, :), reshape(Rt, 3, 3, :)), 3, size(R1,3), size(R1,4))
 end

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -52,9 +52,9 @@ floss(P::Union{fbu(ManifoldProcess), fbu(Deterministic)}, ξhat, ξ::Guide, c) =
 
 #It is sometimes useful to be able to compute the tangent coordinates from the predicted endpoint,
 #eg. if the model needs to reason about its final location during the forward pass.
-function so3_tangent_coordinates_stack(Rt::AbstractArray{T,3}, R1::AbstractArray{T,3}) where T
+function so3_tangent_coordinates_stack(R1::AbstractArray{T,3}, Rt::AbstractArray{T,3}) where T
     eps = T(0.00001)
-    R = batched_mul(batched_transpose(R1), Rt)
+    R = batched_mul(batched_transpose(Rt), R1)
     tr_R = R[1,1,:] .+ R[2,2,:] .+ R[3,3,:]
     theta = acos.(clamp.((tr_R .- 1) ./ 2,T(-0.99),T(0.99)))
     sin_theta = sin.(theta)


### PR DESCRIPTION
Internally, the unbatched computation in so3_tangent_coordinates_stack computes the tangent vector from R1 to Rt, when it is intended to compute the tangent vector from Rt to R1. The unbatched version of the function so3_tangent_coordinates_stack takes arguments (Rt, R1), which is the reverse of the batched version's arguments (Rhat, r)---corresponding to (R1,Rt). When the batched function calls the unbatched one, it passes (rhat, r) in its own order, so it accurately computes the tangent vector from Rt to R1, but internally the computation is inconsistent. 

<img width="751" height="347" alt="image" src="https://github.com/user-attachments/assets/67eb6e8c-09b7-4d22-b26d-c374f0a32b04" />

Changes: 

- Make argument order (R1, Rt) for both, keeping the batched convention.
- Change the unbatched computation to compute the tangent vector from Rt to R1, by computing R = R_t'R_1 instead of R = R_1' R_t. 

Remark: the outputs of the unbatched and batched versions should remain consistent before and after, because the change amounts to changing the name "Rt" to "R1" and the name "R1" to "Rt" in the unbatched so3_tangent_coordinates_stack---so this shouldn't be a breaking change.